### PR TITLE
Interfaces generation

### DIFF
--- a/src/hxtsdgen/Generator.hx
+++ b/src/hxtsdgen/Generator.hx
@@ -149,7 +149,9 @@ class Generator {
             // TODO: maybe it's a good idea to output all-static class that is not referenced
             // elsewhere as a namespace for TypeScript
             var tparams = renderTypeParams(cl.params);
-            parts.push('$indent${if (indent == "") "export " else ""}class $name$tparams {');
+            var isInterface = cl.isInterface;
+            var type = isInterface ? 'interface' : 'class';
+            parts.push('$indent${if (indent == "") "export " else ""}$type $name$tparams {');
 
             {
                 var indent = indent + "\t";
@@ -167,7 +169,7 @@ class Generator {
                         default:
                             throw "wtf";
                     }
-                } else {
+                } else if (!isInterface) {
                     parts.push('${indent}private constructor();');
                 }
 
@@ -188,7 +190,8 @@ class Generator {
                                         prefix += "readonly ";
                                     default:
                                 }
-                                parts.push('$indent$prefix${field.name}: ${renderType(this, field.type)};');
+                                var option = isInterface && isNullable(field) ? '?' : '';
+                                parts.push('$indent$prefix${field.name}$option: ${renderType(this, field.type)};');
 
                             default:
                         }
@@ -209,5 +212,11 @@ class Generator {
         });
     }
 
+    function isNullable(field:ClassField) {
+        return switch (field.type) {
+            case TType(_.get() => _.name => 'Null', _): true;
+            default: false;
+        }
+    }
 
 }

--- a/src/hxtsdgen/TypeRenderer.hx
+++ b/src/hxtsdgen/TypeRenderer.hx
@@ -23,7 +23,13 @@ class TypeRenderer {
 
                     default:
                         // TODO: handle @:expose'd paths
-                        haxe.macro.MacroStringTools.toDotPath(cl.pack, cl.name);
+                        var dotName = haxe.macro.MacroStringTools.toDotPath(cl.pack, cl.name);
+                        // type parameters
+                        if (params.length > 0) {
+                            var genericParams = params.map(function(p) return renderType(ctx, p));
+                            dotName += '<${genericParams.join(',')}>';
+                        }
+                        dotName;
                 }
 
             case TAbstract(_.get() => ab, params):


### PR DESCRIPTION
Correctly generate exported interfaces, including optional fields (based on being nullable).

Also fixes generic types generation (`js.Promise<T>` losing `<T>`)