### PR TITLE
Missing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: haxe
 
 haxe:
-- 3.4.0
+- 3.4.7
 - latest
 
 install:

--- a/test/cases/generic.txt
+++ b/test/cases/generic.txt
@@ -1,7 +1,21 @@
+import js.Promise;
+
 @:expose
 class C<A,B,C> {
 	public function new() {}
 	public function f<T>(a:Array<T>, b:C):T return null;
+}
+
+@:expose class D {
+	public function load():Promise<String> {
+		return Promise.resolve('');
+	}
+}
+
+@:expose class E<T> {
+	public function load():js.Promise<T> {
+		return Promise.resolve(null);
+	}
 }
 
 ----
@@ -9,4 +23,14 @@ class C<A,B,C> {
 export class C<A, B, C> {
 	constructor();
 	f<T>(a: T[], b: C): T;
+}
+
+export class D {
+	private constructor();
+	load(): Promise<string>;
+}
+
+export class E<T> {
+	private constructor();
+	load(): Promise<T>;
 }

--- a/test/cases/interfaces.txt
+++ b/test/cases/interfaces.txt
@@ -1,0 +1,47 @@
+@:expose
+interface C {}
+
+@:expose
+interface D {
+	function test(v:Int):Void;
+}
+
+@:expose
+interface E {
+	var field:String;
+}
+
+@:expose
+interface F {
+	var field(default, null):String;
+}
+
+@:expose
+interface G {
+	var field(get, set):String;
+}
+
+
+----
+
+
+export interface C {
+}
+
+export interface D {
+	test(v: number): void;
+}
+
+export interface E {
+	field: string;
+}
+
+export interface F {
+	readonly field: string;
+}
+
+export interface G {
+	set_field(value: string): string;
+	get_field(): string;
+	field: string;
+}


### PR DESCRIPTION
... for features added without tests in #1 

Had to bump CI to test against 3.4.7 instead of 3.4.0 because property accessors are created in a different order - though the output is correct, the `get_a` and `set_a` are in a different order.