### PR TITLE
Typedef generation

### DIFF
--- a/src/hxtsdgen/Generator.hx
+++ b/src/hxtsdgen/Generator.hx
@@ -190,7 +190,7 @@ class Generator {
                                         prefix += "readonly ";
                                     default:
                                 }
-                                if (read != AccCall || field.meta.has(":isVar")) {
+                                if (read != AccCall) {
                                     var option = isInterface && isNullable(field) ? "?" : "";
                                     parts.push('$indent$prefix${field.name}$option: ${renderType(this, field.type)};');
                                 }

--- a/src/hxtsdgen/Generator.hx
+++ b/src/hxtsdgen/Generator.hx
@@ -174,7 +174,7 @@ class Generator {
                 }
 
                 function addField(field:ClassField, isStatic:Bool) {
-                    if (field.isPublic) {
+                    if (field.isPublic || isPropertyGetterSetter(cl, field)) {
                         if (field.doc != null)
                             parts.push(renderDoc(field.doc, indent));
 
@@ -185,24 +185,15 @@ class Generator {
                                 parts.push(renderFunction(field.name, args, ret, field.params, indent, prefix));
 
                             case [FVar(read, write), _]:
-                                var ro = "";
                                 switch (write) {
-                                    case AccNo|AccNever:
-                                        ro = "readonly ";
-                                    case AccCall:
-                                        ro = "readonly ";
-                                        if (!isInterface)
-                                            parts.push(renderSetter(field, indent, prefix));
+                                    case AccNo|AccNever|AccCall:
+                                        prefix += "readonly ";
                                     default:
                                 }
-                                if (read == AccCall) {
-                                    if (!isInterface)
-                                        parts.push(renderGetter(field, indent, prefix));
-                                    if (!field.meta.has(":isVar"))
-                                        return; // no field
+                                if (read != AccCall || field.meta.has(":isVar")) {
+                                    var option = isInterface && isNullable(field) ? "?" : "";
+                                    parts.push('$indent$prefix${field.name}$option: ${renderType(this, field.type)};');
                                 }
-                                var option = isInterface && isNullable(field) ? "?" : "";
-                                parts.push('$indent$prefix$ro${field.name}$option: ${renderType(this, field.type)};');
 
                             default:
                         }
@@ -221,6 +212,24 @@ class Generator {
             parts.push('$indent}');
             return parts.join("\n");
         });
+    }
+
+    // For a given `method` looking like a `get_x`/`set_x`, look for a matching property
+    function isPropertyGetterSetter(cl:ClassType, method:ClassField) {
+        var re = new EReg('(get|set)_(.*)', '');
+        if (re.match(method.name)) {
+            var name = re.matched(2);
+            for (field in cl.fields.get()) if (field.name == name && isProperty(field)) return true;
+            for (field in cl.statics.get()) if (field.name == name && isProperty(field)) return true;
+        }
+        return false;
+    }
+
+    function isProperty(field) {
+        return switch(field.kind) {
+            case FVar(read, write): write == AccCall || read == AccCall;
+            default: false;
+        };
     }
 
     function renderGetter(field:ClassField, indent:String, prefix:String) {

--- a/test/cases/interfaces.txt
+++ b/test/cases/interfaces.txt
@@ -43,5 +43,4 @@ export interface F {
 export interface G {
 	set_field(value: string): string;
 	get_field(): string;
-	field: string;
 }

--- a/test/cases/properties.txt
+++ b/test/cases/properties.txt
@@ -1,0 +1,134 @@
+@:expose
+class A {
+	public var field(default, null):String;
+}
+
+@:expose
+class B {
+	public var field(default, never):String;
+}
+
+@:expose
+class C {
+	public var field(get, null): String;
+	function get_field(): String { return null; }
+}
+
+@:expose
+class D {
+	public var field(default, set):String;
+	function set_field(value: String): String { return field = value; }
+}
+
+@:expose
+class E {
+	public var field(default, set):String;
+	function set_field(v: String): String { return field = v; }
+}
+
+@:expose
+class F {
+	var _field: String;
+	public var field(get, set): String;
+	function get_field(): String { return null; }
+	function set_field(value: String): String { return _field = value; }
+}
+
+@:expose
+class G {
+	@:isVar public var field(get, set): String;
+	function get_field(): String { return null; }
+	function set_field(value: String): String { return field = value; }
+}
+
+@:expose
+class H {
+	static public var field(default, null):String;
+}
+
+@:expose
+class I {
+	@:isVar static public var field(get, set): String;
+	static function get_field(): String { return null; }
+	static function set_field(value: String): String { return field = value; }
+}
+
+@:expose
+class J<T> {
+	public var field(default, set):T;
+	function set_field(value: T): T { return field = value; }
+}
+
+@:expose
+class K {
+	var _field: String;
+	public var field(get, set): String;
+	public function get_field(): String { return null; }
+	public function set_field(v: String): String { return _field = v; }
+}
+
+----
+
+export class A {
+	private constructor();
+	readonly field: string;
+}
+
+export class B {
+	private constructor();
+	readonly field: string;
+}
+
+export class C {
+	private constructor();
+	get_field(): string;
+}
+
+export class D {
+	private constructor();
+	readonly field: string;
+	set_field(value: string): string;
+}
+
+export class E {
+	private constructor();
+	readonly field: string;
+	set_field(v: string): string;
+}
+
+export class F {
+	private constructor();
+	get_field(): string;
+	set_field(value: string): string;
+}
+
+export class G {
+	private constructor();
+	readonly field: string;
+	get_field(): string;
+	set_field(value: string): string;
+}
+
+export class H {
+	private constructor();
+	static readonly field: string;
+}
+
+export class I {
+	private constructor();
+	static readonly field: string;
+	static get_field(): string;
+	static set_field(value: string): string;
+}
+
+export class J<T> {
+	private constructor();
+	readonly field: T;
+	set_field(value: T): T;
+}
+
+export class K {
+	private constructor();
+	get_field(): string;
+	set_field(v: string): string;
+}

--- a/test/cases/properties.txt
+++ b/test/cases/properties.txt
@@ -104,7 +104,6 @@ export class F {
 
 export class G {
 	private constructor();
-	readonly field: string;
 	get_field(): string;
 	set_field(value: string): string;
 }
@@ -116,7 +115,6 @@ export class H {
 
 export class I {
 	private constructor();
-	static readonly field: string;
 	static get_field(): string;
 	static set_field(value: string): string;
 }

--- a/test/cases/typedef.txt
+++ b/test/cases/typedef.txt
@@ -1,0 +1,71 @@
+typedef W = {
+	var w:Int;
+}
+
+@:expose
+interface X {
+	var x:Int;
+}
+
+@:expose("Y2")
+typedef Y = {
+	var y:Int;
+}
+
+@:expose
+typedef Z = {
+	function f1(a:String):Int;
+	var f2: String -> Int;
+};
+
+@:expose
+class A {
+	public function f():X {
+		return null;
+	}
+}
+
+@:expose
+class B {
+	public function f():Y {
+		return { y: 1 };
+	}
+}
+
+@:expose
+interface C {
+	function f1():W;
+	function f2():X;
+	function f3():Z;
+}
+
+----
+
+export interface X {
+	x: number;
+}
+
+export type Y2 = {
+	y: number;
+}
+
+export type Z = {
+	f1(a: string): number;
+	f2: (arg0: string) => number;
+}
+
+export class A {
+	private constructor();
+	f(): X;
+}
+
+export class B {
+	private constructor();
+	f(): Y2;
+}
+
+export interface C {
+	f1(): {w: number};
+	f2(): X;
+	f3(): Z;
+}


### PR DESCRIPTION
Typedef anonymous structure can now be exposed, and will be refered to instead of the anonymous structure.

Also fixes incomplete handling of named exports.

```haxe
@:expose("X2") 
typedef X = {
   x:Int;
}

@:expose
interface A {
   var field:X;
}
```
Produces:
```haxe
export type X2 = {
   x: number;
}

export interface A {
   field: X2;
}
```

- Implements #3
- Merge after #11 