### PR TITLE
Fix `native` metadata support

### DIFF
--- a/src/hxtsdgen/CodeGen.hx
+++ b/src/hxtsdgen/CodeGen.hx
@@ -55,11 +55,15 @@ class CodeGen {
 
     static public function getExposePath(m:MetaAccess):Array<String> {
         return switch (m.extract(":expose")) {
-            case []: null; // not exposed
-            case [{params: []}]: null;
             case [{params: [macro $v{(s:String)}]}]: s.split(".");
-            case [_]: throw "invalid @:expose argument!"; // probably handled by compiler
-            case _: throw "multiple @:expose metadata!"; // is this okay?
+            case _: m.has(":native") ? getNativePath(m) : null;
+        }
+    }
+
+    static function getNativePath(m:MetaAccess):Array<String> {
+        return switch (m.extract(":native")) {
+            case [{params: [macro $v{(s:String)}]}]: s.split(".");
+            case _: null;
         }
     }
 

--- a/src/hxtsdgen/Selector.hx
+++ b/src/hxtsdgen/Selector.hx
@@ -46,7 +46,7 @@ class Selector {
     public function ensureIncluded(t:Type) {
         // A type is referenced, maybe it needs to be generated as well
         switch [t, t.follow()] {
-            case [_, TInst(_.get() => cl, _)] if (!cl.meta.has(":expose") && !cl.meta.has(":native")):
+            case [_, TInst(_.get() => cl, _)] if (!cl.isExtern && !cl.meta.has(":expose")):
                 var key = cl.pack.join('.') + '.' + cl.name;
                 if (!autoIncluded.exists(key)) {
                     autoIncluded.set(key, true);

--- a/src/hxtsdgen/TypeRenderer.hx
+++ b/src/hxtsdgen/TypeRenderer.hx
@@ -89,14 +89,9 @@ class TypeRenderer {
     }
 
     static function formatName(ctx:Selector, t: { pack:Array<String>, name:String, meta:MetaAccess }, params:Array<Type>) {
-        if (t.meta.has(":expose")) {
-            var exposePath = CodeGen.getExposePath(t.meta);
-            if (exposePath != null) {
-                return exposePath.join('.');
-            }
-        }
-
-        var dotName = haxe.macro.MacroStringTools.toDotPath(t.pack, t.name);
+        var exposePath = CodeGen.getExposePath(t.meta);
+        if (exposePath == null) exposePath = t.pack.concat([t.name]);
+        var dotName = exposePath.join('.');
         // type parameters
         if (params.length > 0) {
             var genericParams = params.map(function(p) return renderType(ctx, p));

--- a/test/cases/native.txt
+++ b/test/cases/native.txt
@@ -1,0 +1,37 @@
+@:expose("B")
+@:native("C")
+class A {}
+
+@:expose
+@:native("E")
+class D {}
+
+@:native("G")
+class F {}
+
+@:expose
+class H {
+	@:expose
+	@:native("i")
+	static function h(a0: F, a1: js.html.HtmlElement) {}
+}
+
+----
+
+export class B {
+	private constructor();
+}
+
+export class E {
+	private constructor();
+}
+
+export class H {
+	private constructor();
+}
+
+export class G {
+	private constructor();
+}
+
+export function i(a0: G, a1: HTMLHtmlElement): void;


### PR DESCRIPTION
Correct support for `@:native` meta and ignoring extern classes.

Fixes #19 