### PR TITLE
Respect class extend/implement

### DIFF
--- a/src/hxtsdgen/Selector.hx
+++ b/src/hxtsdgen/Selector.hx
@@ -29,18 +29,41 @@ class Selector {
                         if (Generator.GEN_ENUM_TS || cl.meta.has(":expose"))
                             exposed.push(EEnum(cl));
                     } else {
-                        if (cl.meta.has(":expose")) {
-                            exposed.push(EClass(cl));
-                        }
-                        for (f in cl.statics.get()) {
-                            if (f.meta.has(":expose"))
-                                exposed.push(EMethod(cl, f));
-                        }
+                        exposeClass(cl);
                     }
                 default:
             }
         }
         return exposed.length;
+    }
+
+    function exposeClass(cl:ClassType, autoInclude = false) {
+        if (autoInclude) {
+            if (autoIncluded.exists(cl.name)) return;
+            autoIncluded.set(cl.name, true);
+        }
+
+        if (autoInclude || cl.meta.has(":expose")) {
+            if (cl.interfaces != null && cl.interfaces.length > 0) {
+                for (item in cl.interfaces) {
+                    var sup = item.t.get();
+                    if (!sup.meta.has(":expose")) {
+                        exposeClass(sup, true);
+                    }
+                }
+            }
+            if (cl.superClass != null) {
+                var sup = cl.superClass.t.get();
+                if (!sup.meta.has(":expose")) {
+                    exposeClass(sup, true);
+                }
+            }
+            exposed.push(EClass(cl));
+        }
+        for (f in cl.statics.get()) {
+            if (f.meta.has(":expose"))
+                exposed.push(EMethod(cl, f));
+        }
     }
 
     public function ensureIncluded(t:Type) {
@@ -53,14 +76,14 @@ class Selector {
                     onAutoInclude([EClass(cl)]);
                 }
                 return true;
-            case [TType(_.get() => tt, _), TAnonymous(_.get() => anon)]:
+            case [TType(_.get() => tt, _), TAnonymous(_.get() => anon)] if (!tt.meta.has(":expose")):
                 var key = tt.pack.join('.') + '.' + tt.name;
                 if (!autoIncluded.exists(key)) {
                     autoIncluded.set(key, true);
                     onAutoInclude([ETypedef(tt, anon)]);
                 }
                 return true;
-            case [TAbstract(_.get() => ab, params), _]:
+            case [TAbstract(_.get() => ab, params), _] if (!ab.meta.has(":expose")):
                 var cl = ab.impl.get();
                 if (cl.meta.has(':enum')) {
                     var key = cl.pack.join('.') + '.' + cl.name;

--- a/test/cases/inheritance.txt
+++ b/test/cases/inheritance.txt
@@ -1,0 +1,49 @@
+interface C {
+	function testC():Void;
+}
+
+interface D {
+	function testD():Void;
+}
+
+class B {
+	public function new() {}
+	public function testB():Void {}
+}
+
+@:expose
+class A extends B implements C implements D {
+	public function new() {
+		super();
+	}
+	public function testC() {};
+	public function testD() {};
+}
+
+@:expose
+interface E extends D {}
+
+----
+
+
+export interface D {
+	testD(): void;
+}
+
+export interface C {
+	testC(): void;
+}
+
+export class B {
+	constructor();
+	testB(): void;
+}
+
+export class A extends B implements D, C {
+	constructor();
+	testC(): void;
+	testD(): void;
+}
+
+export interface E extends D {
+}


### PR DESCRIPTION
- include `extend/implement` related types
- warn when a class is referenced but not exposed (it's not exposed at the JS level)
- ensure types aren't included twice

Fixes #22 
