### PR TITLE
Update ArgsRenderer.hx. First optional argument wasn't rendered as optional in TS.

### DIFF
--- a/src/hxtsdgen/ArgsRenderer.hx
+++ b/src/hxtsdgen/ArgsRenderer.hx
@@ -25,7 +25,7 @@ class ArgsRenderer {
         for (i in 0...args.length) {
             var arg = args[i];
             var name = if (arg.name != "") arg.name else 'arg$i';
-            var opt = if (arg.opt && i > noOptionalUntil) "?" else "";
+            var opt = if (arg.opt && i >= noOptionalUntil) "?" else "";
             tsArgs.push('$name$opt: ${renderType(ctx, arg.t)}');
         }
         return tsArgs.join(", ");


### PR DESCRIPTION
Here is an example of how it worked before: 

Haxe:
```
class Vec3 {
    public inline function new(x:Float = 0, y:Float = 0, z:Float = 0) {
         ...
    }
}
```
TypeScript Declarations:
``` 
export class Vec3 {
    constructor(x: number, y?: number, z?: number);
}
```

After this fix ts declarations will look like:
TypeScript Declarations:
``` 
export class Vec3 {
    constructor(x?: number, y?: number, z?: number);
}
```