### PR TITLE
Use correct key when checking for autoinclude

### DIFF
--- a/src/hxtsdgen/Selector.hx
+++ b/src/hxtsdgen/Selector.hx
@@ -40,8 +40,9 @@ class Selector {
 
     function exposeClass(cl:ClassType, autoInclude = false) {
         if (autoInclude) {
-            if (autoIncluded.exists(cl.name)) return;
-            autoIncluded.set(cl.name, true);
+            var key = cl.pack.join('.') + '.' + cl.name;
+            if (autoIncluded.exists(key)) return;
+            autoIncluded.set(key, true);
         }
 
         if (autoInclude || cl.meta.has(":expose")) {

--- a/src/hxtsdgen/TypeRenderer.hx
+++ b/src/hxtsdgen/TypeRenderer.hx
@@ -39,8 +39,7 @@ class TypeRenderer {
                         "void";
 
                     case [{pack: [], name: "Null"}, [realT]]: // Haxe 4.x
-                        // TODO: generate `| null` union unless it comes from an optional field?
-                        renderType(ctx, realT, paren);
+                        renderType(ctx, realT, paren) + " | null";
 
                     case [{pack: ["haxe", "extern"], name: "EitherType"}, [aT, bT]]:
                         '${renderType(ctx, aT, true)} | ${renderType(ctx, bT, true)}';
@@ -62,8 +61,7 @@ class TypeRenderer {
             case TType(_.get() => dt, params):
                 switch [dt, params] {
                     case [{pack: [], name: "Null"}, [realT]]: // Haxe 3.x
-                        // TODO: generate `| null` union unless it comes from an optional field?
-                        renderType(ctx, realT, paren);
+                        renderType(ctx, realT, paren) + " | null";
 
                     default:
                         switch (dt.type) {

--- a/src/hxtsdgen/TypeRenderer.hx
+++ b/src/hxtsdgen/TypeRenderer.hx
@@ -17,7 +17,7 @@ class TypeRenderer {
                         "string";
 
                     case [{pack: [], name: "Array"}, [elemT]]:
-                        renderType(ctx, elemT, true) + "[]";
+                        "Array<" + renderType(ctx, elemT, true) + ">";
 
                     case [{name: name, kind: KTypeParameter(_)}, _]:
                         name;


### PR DESCRIPTION
Need to check for whole pack + name, not just class name.